### PR TITLE
複数クライアント対応機能を追加

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -14,7 +14,7 @@ export const list = defineCommand({
   },
 });
 
-function listFunc(client: string) {
+function listFunc(client?: string) {
   let pathfromhomedir: string = ".mcp-manager.json";
   switch (client) {
     case "claude-code": {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,15 +7,30 @@ export const list = defineCommand({
     description: "mcp-managerに登録してある MCP サーバーを一覧表示します",
   },
   args: {
-    // name: { type: "string", required: true },
+    client: { type: "string", required: false },
   },
   run({ args }) {
-    listFunc();
+    listFunc(args.client);
   },
 });
 
-function listFunc() {
-  const obj = importMCPManager();
+function listFunc(client: string) {
+  let pathfromhomedir: string = ".mcp-manager.json";
+  switch (client) {
+    case "claude-code": {
+      pathfromhomedir = ".claude.json";
+      break;
+    }
+    case "gemini-cli": {
+      pathfromhomedir = ".gemini/settings.json";
+      break;
+    }
+    // case "claude": {
+    //   pathfromhomedir = "Library/'Application Support'/Claude";
+    //   break;
+    // }
+  }
+  const obj = importMCPManager(pathfromhomedir);
 
   const mcps = Object.keys(obj.mcpServers);
   Object.values(mcps).forEach((serverName) => {

--- a/src/import-settings.ts
+++ b/src/import-settings.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export function importMCPManager() {
-  const filePath = join(homedir(), ".mcp-manager.json");
+export function importMCPManager(pathfromhomedir: string) {
+  const filePath = join(homedir(), pathfromhomedir);
   if (!existsSync(filePath)) {
     throw new Error("ファイルが存在しません");
   }


### PR DESCRIPTION
## 概要
listコマンドに`--client`オプションを追加し、複数のAIクライアントの設定ファイルに対応する機能を実装しました。

## 変更内容
- **listコマンドの拡張**: `--client`引数でクライアント種類を指定可能
- **対応クライアント**: 
  - `claude-code` → `.claude.json`
  - `gemini-cli` → `.gemini/settings.json`
  - デフォルト → `.mcp-manager.json`
- **関数のパラメータ化**: `importMCPManager`関数に設定ファイルパスパラメータを追加

## テスト方法
```bash
# デフォルト（.mcp-manager.json）
bun src/index.ts list

# Claude Code設定
bun src/index.ts list --client claude-code

# Gemini CLI設定
bun src/index.ts list --client gemini-cli
```

🤖 Generated with [Claude Code](https://claude.ai/code)