### PR TITLE
addコマンドの基本構造を追加

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,0 +1,11 @@
+export function addFunc(
+  name: string,
+  command: string,
+  force?: boolean,
+  config?: string[],
+  env?: string[],
+) {
+  console.log(
+    `name: ${name}\ncommand: ${command}\nforce: ${force}\nenv: ${env}\nconfig: ${config}`,
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 const program = new Command();
 import { listFunc } from "./commands/list";
+import { addFunc } from "./commands/add";
 
 program.version("0.0.1", "-v, --version");
 
@@ -10,6 +11,18 @@ program
   .option("-c, --client <clientName>", "クライアント名")
   .action((options) => {
     listFunc(options.client);
+  });
+
+program
+  .command("add")
+  .description("mcpサーバーをmcp-managerに登録します")
+  .argument("<name>", "MCPサーバー名")
+  .argument("<command>", "実行コマンド")
+  .option("-e, --env [key=value...]", "環境変数を設定")
+  .option("-f, --force", "強制上書き")
+  .option("-c, --config [path...]", "設定ファイルのパス")
+  .action((name, command, options) => {
+    addFunc(name, command, options.force, options.config, options.env);
   });
 
 program.parse();


### PR DESCRIPTION
MCPサーバーを登録するためのaddコマンドを実装。
- CLI引数とオプション定義（name, command, env, force, config）
- 基本的な実装関数をsrc/commands/add.tsに追加
- 現在はコンソール出力のみの実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)