### PR TITLE
addコマンド機能の実装

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -13,6 +13,5 @@ export function addFunc(
 		`name: ${name}\ncommand: ${command}\nargs: ${args}\nforce: ${force}\nenv: ${env}\nconfig: ${config}`,
 	);
 	const obj = importMCPSettings(config ? config : undefined);
-	obj[name] = { command: command, args: args, env: env };
-	exportMCPSettings(obj, config ? config : undefined);
+	obj.mcpServers[name] = { command: command, args: args, env: env };
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -14,4 +14,10 @@ export function addFunc(
 	);
 	const obj = importMCPSettings(config ? config : undefined);
 	obj.mcpServers[name] = { command: command, args: args, env: env };
+	if (force || !(name in obj.mcpServers)) {
+		exportMCPSettings(obj, config ? config : undefined);
+	} else {
+		console.log("すでに同じ名前のMCPサーバーが存在します");
+	}
+
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,12 +1,18 @@
+import { exportMCPSettings } from "../export-settings";
+import { importMCPSettings } from "../import-settings";
+
 export function addFunc(
 	name: string,
 	command: string,
 	args: string[],
 	force?: boolean,
-	config?: string[],
+	config?: string,
 	env?: string[],
 ) {
 	console.log(
 		`name: ${name}\ncommand: ${command}\nargs: ${args}\nforce: ${force}\nenv: ${env}\nconfig: ${config}`,
 	);
+	const obj = importMCPSettings(config ? config : undefined);
+	obj[name] = { command: command, args: args, env: env };
+	exportMCPSettings(obj, config ? config : undefined);
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,11 +1,12 @@
 export function addFunc(
 	name: string,
 	command: string,
+	args: string[],
 	force?: boolean,
 	config?: string[],
 	env?: string[],
 ) {
 	console.log(
-		`name: ${name}\ncommand: ${command}\nforce: ${force}\nenv: ${env}\nconfig: ${config}`,
+		`name: ${name}\ncommand: ${command}\nargs: ${args}\nforce: ${force}\nenv: ${env}\nconfig: ${config}`,
 	);
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,4 +1,4 @@
-import { importMCPManager } from "../import-settings";
+import { importMCPSettings } from "../import-settings";
 
 export function listFunc(client?: string) {
 	let pathfromhomedir: string = ".mcp-manager.json";
@@ -25,7 +25,7 @@ export function listFunc(client?: string) {
 			throw new Error("無効なクライアント名です");
 		}
 	}
-	const obj = importMCPManager(pathfromhomedir);
+	const obj = importMCPSettings(pathfromhomedir);
 
 	const mcps = Object.keys(obj.mcpServers);
 	Object.values(mcps).forEach((serverName) => {

--- a/src/export-settings.ts
+++ b/src/export-settings.ts
@@ -1,0 +1,18 @@
+import { writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function exportMCPSettings(
+    obj: any,
+    pathfromhomedir: string = ".mcp-manager.json",
+) {
+    const filePath = join(homedir(), pathfromhomedir);
+    if (!("mcpServers" in obj)) {
+        throw new Error("mcpServersが存在しません");
+    }
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+        throw new Error("無効なJSON形式");
+    }
+    const formatterJson = JSON.stringify(obj, null, 2);
+    writeFileSync(filePath, formatterJson);
+}

--- a/src/import-settings.ts
+++ b/src/import-settings.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export function importMCPManager(pathfromhomedir: string) {
+export function importMCPManager(pathfromhomedir: string=".mcp-manager.json") {
 	const filePath = join(homedir(), pathfromhomedir);
 	if (!existsSync(filePath)) {
 		throw new Error("ファイルが存在しません");

--- a/src/import-settings.ts
+++ b/src/import-settings.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export function importMCPManager(pathfromhomedir: string=".mcp-manager.json") {
+export function importMCPSettings(pathfromhomedir: string = ".mcp-manager.json") {
 	const filePath = join(homedir(), pathfromhomedir);
 	if (!existsSync(filePath)) {
 		throw new Error("ファイルが存在しません");

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,14 @@ program
 program
 	.command("add")
 	.description("mcpサーバーをmcp-managerに登録します")
+	.option("-e, --env [key=value...]", "環境変数を設定")
+	.option("-c, --config [path...]", "設定ファイルのパス")
+	.option("-f, --force", "強制上書き")
 	.argument("<name>", "MCPサーバー名")
 	.argument("<command>", "実行コマンド")
-	.option("-e, --env [key=value...]", "環境変数を設定")
-	.option("-f, --force", "強制上書き")
-	.option("-c, --config [path...]", "設定ファイルのパス")
-	.action((name, command, options) => {
-		addFunc(name, command, options.force, options.config, options.env);
+	.argument("[args...]", "追加の引数")
+	.action((name, command, args, options) => {
+		addFunc(name, command, args, options.force, options.config, options.env);
 	});
 
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ program
 	.command("add")
 	.description("mcpサーバーをmcp-managerに登録します")
 	.option("-e, --env [key=value...]", "環境変数を設定")
-	.option("-c, --config [path...]", "設定ファイルのパス")
+	.option("-c, --config <path>", "設定ファイルのパス")
 	.option("-f, --force", "強制上書き")
 	.argument("<name>", "MCPサーバー名")
 	.argument("<command>", "実行コマンド")


### PR DESCRIPTION
## 概要
- MCPサーバーを登録する `add` コマンドを実装
- 設定ファイルの読み書き機能を追加
- `list` コマンドと連携するための基盤を整備

## 主な変更点
- `src/commands/add.ts`: MCPサーバー登録機能の実装
- `src/export-settings.ts`: 設定ファイル書き出し機能の追加
- `src/import-settings.ts`: 関数名を `importMCPSettings` に変更、デフォルト引数を追加
- `src/index.ts`: `add` コマンドのCLI引数定義を整備（args引数、オプション順序の調整）

## テスト計画
- [ ] `mcp-manager add <name> <command>` で基本的な登録が動作することを確認
- [ ] `--env` オプションで環境変数が正しく設定されることを確認
- [ ] `--config` オプションでカスタム設定ファイルパスが使用できることを確認
- [ ] `--force` オプションで既存設定の上書きが動作することを確認
- [ ] 追加の引数が正しく `args` 配列として渡されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)