### PR TITLE
環境変数の配列からオブジェクトへの変換ロジックを修正

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -7,14 +7,25 @@ export function addFunc(
   args: string[],
   force?: boolean,
   config?: string,
-  env?: Record<string, string>,
+  env?: string[],
 ) {
   console.log(
     `name: ${name}\ncommand: ${command}\nargs: ${args}\nforce: ${force}\nenv: ${env}\nconfig: ${config}`,
   );
+
+  let newEnv = {};
+
+  if (env) {
+    newEnv = env.reduce((acc, e) => {
+      const [key, value] = e.split("=");
+      acc[key] = value;
+      return acc;
+    }, {} as Record<string, string>);
+  }
+
   const obj = importMCPSettings(config ? config : undefined);
   if (force || !(name in obj.mcpServers)) {
-    obj.mcpServers[name] = { command: command, args: args, env: env };
+    obj.mcpServers[name] = { command: command, args: args, env: newEnv };
     exportMCPSettings(obj, config ? config : undefined);
   } else {
     console.log("すでに同じ名前のMCPサーバーが存在します");


### PR DESCRIPTION
## 概要
`add` コマンドの環境変数処理を修正し、配列形式からオブジェクト形式への変換を正しく実装しました。

## 変更内容
- `env` パラメータの型を `Record<string, string>` から `string[]` に変更
- `Array.reduce()` を使用して環境変数配列（例: `["CIPHER_EMBEDDER=local"]`）をオブジェクト（例: `{"CIPHER_EMBEDDER": "local"}`）に正しく変換
- 以前の誤った実装（`map` と `{ key: value }` の組み合わせ）を修正

## 修正前の問題
```typescript
newEnv = env.map((e) => {
  const [key, value] = e.split("=");
  return { key: value };  // ❌ keyが文字列リテラルになる
});
```

## 修正後
```typescript
newEnv = env.reduce((acc, e) => {
  const [key, value] = e.split("=");
  acc[key] = value;  // ✅ 動的プロパティ名
  return acc;
}, {} as Record<string, string>);
```

## テスト
- [ ] `bun run src/index.ts add` コマンドで環境変数が正しくオブジェクトに変換されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)