### PR TITLE
実行時バリデーション機能の追加とリファクタリング

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,34 +1,35 @@
 import { importMCPSettings } from "../import-settings";
+import type { Config } from "../schemas";
 
 export function listFunc(client?: string) {
-	let pathfromhomedir: string = ".mcp-manager.json";
-	switch (client) {
-		case "claude-code": {
-			pathfromhomedir = ".claude.json";
-			break;
-		}
-		case "gemini-cli": {
-			pathfromhomedir = ".gemini/settings.json";
-			break;
-		}
-		case "claude": {
-			pathfromhomedir =
-				"Library/Application Support/Claude/claude_desktop_config.json";
-			break;
-		}
-		case undefined:
-		case "": {
-			// デフォルトの.mcp-manager.jsonを使用
-			break;
-		}
-		default: {
-			throw new Error("無効なクライアント名です");
-		}
-	}
-	const obj = importMCPSettings(pathfromhomedir);
+  let pathfromhomedir: string = ".mcp-manager.json";
+  switch (client) {
+    case "claude-code": {
+      pathfromhomedir = ".claude.json";
+      break;
+    }
+    case "gemini-cli": {
+      pathfromhomedir = ".gemini/settings.json";
+      break;
+    }
+    case "claude": {
+      pathfromhomedir =
+        "Library/Application Support/Claude/claude_desktop_config.json";
+      break;
+    }
+    case undefined:
+    case "": {
+      // デフォルトの.mcp-manager.jsonを使用
+      break;
+    }
+    default: {
+      throw new Error("無効なクライアント名です");
+    }
+  }
+  const obj: Config = importMCPSettings(pathfromhomedir);
 
-	const mcps = Object.keys(obj.mcpServers);
-	Object.values(mcps).forEach((serverName) => {
-		console.log(serverName);
-	});
+  const mcps = Object.keys(obj.mcpServers);
+  Object.values(mcps).forEach((serverName) => {
+    console.log(serverName);
+  });
 }

--- a/src/export-settings.ts
+++ b/src/export-settings.ts
@@ -4,18 +4,19 @@ import { join } from "node:path";
 import { ConfigSchema, type Config } from "./schemas";
 
 export function exportMCPSettings(
-  obj: Config,
-  pathfromhomedir: string = ".mcp-manager.json",
+	obj: Config,
+	pathfromhomedir: string = ".mcp-manager.json",
 ) {
-  try {
-    const validatedObj = ConfigSchema.parse(obj);
-    // 以降の処理（ファイル書き込み）
-  } catch (error) {
-    // エラーハンドリング
-    throw new Error(`設定が不正です: ${error}`);
-  }
+	const result = ConfigSchema.safeParse(obj);
 
-  const filePath = join(homedir(), pathfromhomedir);
-  const formatterJson = JSON.stringify(obj, null, 2);
-  writeFileSync(filePath, formatterJson);
+	if (!result.success) {
+		const errorMessages = result.error.issues
+			.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+			.join(", ");
+		throw new Error(`設定が不正です: ${errorMessages}`);
+	}
+
+	const filePath = join(homedir(), pathfromhomedir);
+	const formatterJson = JSON.stringify(result.data, null, 2);
+	writeFileSync(filePath, formatterJson);
 }

--- a/src/export-settings.ts
+++ b/src/export-settings.ts
@@ -1,12 +1,20 @@
 import { writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { Config } from "./schemas";
+import { ConfigSchema, type Config } from "./schemas";
 
 export function exportMCPSettings(
   obj: Config,
   pathfromhomedir: string = ".mcp-manager.json",
 ) {
+  try {
+    const validatedObj = ConfigSchema.parse(obj);
+    // 以降の処理（ファイル書き込み）
+  } catch (error) {
+    // エラーハンドリング
+    throw new Error(`設定が不正です: ${error}`);
+  }
+
   const filePath = join(homedir(), pathfromhomedir);
   const formatterJson = JSON.stringify(obj, null, 2);
   writeFileSync(filePath, formatterJson);

--- a/src/export-settings.ts
+++ b/src/export-settings.ts
@@ -2,21 +2,17 @@ import { writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { ConfigSchema, type Config } from "./schemas";
+import { validateConfig } from "./validate";
 
 export function exportMCPSettings(
-	obj: Config,
-	pathfromhomedir: string = ".mcp-manager.json",
+  obj: Config,
+  pathfromhomedir: string = ".mcp-manager.json",
 ) {
-	const result = ConfigSchema.safeParse(obj);
+  const result = ConfigSchema.safeParse(obj);
 
-	if (!result.success) {
-		const errorMessages = result.error.issues
-			.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
-			.join(", ");
-		throw new Error(`設定が不正です: ${errorMessages}`);
-	}
+  validateConfig(result);
 
-	const filePath = join(homedir(), pathfromhomedir);
-	const formatterJson = JSON.stringify(result.data, null, 2);
-	writeFileSync(filePath, formatterJson);
+  const filePath = join(homedir(), pathfromhomedir);
+  const formatterJson = JSON.stringify(result.data, null, 2);
+  writeFileSync(filePath, formatterJson);
 }

--- a/src/import-settings.ts
+++ b/src/import-settings.ts
@@ -17,5 +17,5 @@ export function importMCPSettings(
   const result = ConfigSchema.safeParse(obj);
   validateConfig(result);
 
-  return obj;
+  return result.data;
 }

--- a/src/import-settings.ts
+++ b/src/import-settings.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { ConfigSchema, type Config } from "./schemas";
+import { validateConfig } from "./validate";
 
 export function importMCPSettings(
   pathfromhomedir: string = ".mcp-manager.json",
@@ -11,6 +12,10 @@ export function importMCPSettings(
     throw new Error("ファイルが存在しません");
   }
   const jsonString = readFileSync(filePath, "utf8");
-  const obj: Config = ConfigSchema.parse(JSON.parse(jsonString));
+  const obj: Config = JSON.parse(jsonString);
+
+  const result = ConfigSchema.safeParse(obj);
+  validateConfig(result);
+
   return obj;
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,13 +1,29 @@
-import { type ZodSafeParseResult } from "zod";
+import { type ZodError } from "zod";
 import { type Config } from "./schemas";
 
+type SafeParseSuccess<Output> = {
+	success: true;
+	data: Output;
+	error?: never;
+};
+
+type SafeParseFailure<Input> = {
+	success: false;
+	error: ZodError<Input>;
+	data?: never;
+};
+
+type SafeParseResult<Input, Output> =
+	| SafeParseSuccess<Output>
+	| SafeParseFailure<Input>;
+
 export function validateConfig(
-  result: ZodSafeParseResult<Config>,
-): asserts result is { success: true; data: Config } {
-  if (!result.success) {
-    const errorMessages = result.error.issues
-      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
-      .join(", ");
-    throw new Error(`設定が不正です: ${errorMessages}`);
-  }
+	result: SafeParseResult<unknown, Config>,
+): asserts result is SafeParseSuccess<Config> {
+	if (!result.success) {
+		const errorMessages = result.error.issues
+			.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+			.join(", ");
+		throw new Error(`設定が不正です: ${errorMessages}`);
+	}
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,11 @@
+import { type ZodSafeParseResult } from "zod";
+import { type Config } from "./schemas";
+
+export function validateConfig(result: ZodSafeParseResult<Config>): void {
+  if (!result.success) {
+    const errorMessages = result.error.issues
+      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+      .join(", ");
+    throw new Error(`設定が不正です: ${errorMessages}`);
+  }
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,7 +1,9 @@
 import { type ZodSafeParseResult } from "zod";
 import { type Config } from "./schemas";
 
-export function validateConfig(result: ZodSafeParseResult<Config>): void {
+export function validateConfig(
+  result: ZodSafeParseResult<Config>,
+): asserts result is { success: true; data: Config } {
   if (!result.success) {
     const errorMessages = result.error.issues
       .map((issue) => `${issue.path.join(".")}: ${issue.message}`)


### PR DESCRIPTION
## 概要
MCP設定の読み書き時に、Zodによる実行時バリデーションを追加しました。TypeScriptの型チェックだけでは不十分だった実行時の型安全性を強化しています。

## 変更内容

### 追加機能
- **実行時バリデーション**: `exportMCPSettings`と`importMCPSettings`でZodによるスキーマ検証を実装
- **詳細なエラーメッセージ**: バリデーション失敗時に、どのフィールドがどう不正かを具体的に表示
- **validate.ts**: バリデーションロジックを専用ファイルに分離し、再利用性を向上

### リファクタリング
- `.parse()`から`.safeParse()`への変更で、エラー処理をより明示的に
- `result.data`を使用することで、Zodの型変換機能に対応した設計
- 関心の分離により、コードの保守性が向上

## 技術的な改善点
1. **型安全性の強化**: `JSON.parse`の戻り値に対する実行時チェック
2. **将来の拡張性**: `z.coerce`や`z.transform`などのZod機能に対応
3. **DRY原則の適用**: バリデーションロジックを`validateConfig`関数として共通化

## テスト計画
- [ ] 正常な設定ファイルの読み込み
- [ ] 不正な設定ファイルでのエラー表示
- [ ] エラーメッセージの分かりやすさ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>