### PR TITLE
applyコマンドを削除し、コード構造を改善

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -3,47 +3,46 @@ import { importMCPSettings } from "../import-settings";
 import type { Config } from "../schemas";
 
 export function addFunc(
-	name: string,
-	command: string,
-	args: string[],
-	force?: boolean,
-	config?: string,
-	env?: string[],
+  name: string,
+  command: string,
+  args: string[],
+  force?: boolean,
+  env?: string[],
 ) {
-	console.log(
-		`name: ${name}\ncommand: ${command}\nargs: ${args}\nforce: ${force}\nenv: ${env}\nconfig: ${config}`,
-	);
+  console.log(
+    `name: ${name}\ncommand: ${command}\nargs: ${args}\nforce: ${force}\nenv: ${env}`,
+  );
 
-	let newEnv = {};
+  let newEnv = {};
 
-	/*
+  /*
   forEachの省略版みたいなやつ。要素の個数分追加処理が入る
   acc: 現在操作しているオブジェクト、e: 現在処理している文字列
   eに最初の文字列 string1=string2 が入る
   それから keyとvalue を生成して、accに追加する(初期値は{})
   */
-	if (env) {
-		newEnv = env.reduce(
-			(acc, e) => {
-				const [key, value] = e.split("=");
-				if (key && value) {
-					acc[key] = value;
-				} else {
-					throw new Error(
-						"envが無効な形式です。=で2つの文字列をつなげてください。",
-					);
-				}
-				return acc;
-			},
-			{} as Record<string, string>,
-		);
-	}
+  if (env) {
+    newEnv = env.reduce(
+      (acc, e) => {
+        const [key, value] = e.split("=");
+        if (key && value) {
+          acc[key] = value;
+        } else {
+          throw new Error(
+            "envが無効な形式です。=で2つの文字列をつなげてください。",
+          );
+        }
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+  }
 
-	const obj: Config = importMCPSettings(config ? config : undefined);
-	if (force || !(name in obj.mcpServers)) {
-		obj.mcpServers[name] = { command: command, args: args, env: newEnv };
-		exportMCPSettings(obj, config ? config : undefined);
-	} else {
-		console.log("すでに同じ名前のMCPサーバーが存在します");
-	}
+  const obj: Config = importMCPSettings();
+  if (force || !(name in obj.mcpServers)) {
+    obj.mcpServers[name] = { command: command, args: args, env: newEnv };
+    exportMCPSettings(obj);
+  } else {
+    console.log("すでに同じ名前のMCPサーバーが存在します");
+  }
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -6,11 +6,12 @@ export function addFunc(
   name: string,
   command: string,
   args: string[],
+  client?: string,
   force?: boolean,
   env?: string[],
 ) {
   console.log(
-    `name: ${name}\ncommand: ${command}\nargs: ${args}\nforce: ${force}\nenv: ${env}`,
+    `name: ${name}\ncommand: ${command}\nargs: ${args}\nclient: ${client}\nforce: ${force}\nenv: ${env}`,
   );
 
   let newEnv = {};

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,3 +1,4 @@
+import { getPathFromClientName } from "../return-client-settings";
 import { exportMCPSettings } from "../export-settings";
 import { importMCPSettings } from "../import-settings";
 import type { Config } from "../schemas";
@@ -39,7 +40,9 @@ export function addFunc(
     );
   }
 
-  const obj: Config = importMCPSettings();
+  const filePath = getPathFromClientName(client);
+
+  const obj: Config = importMCPSettings(filePath);
   if (force || !(name in obj.mcpServers)) {
     obj.mcpServers[name] = { command: command, args: args, env: newEnv };
     exportMCPSettings(obj);

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,8 +1,0 @@
-export function applyFunc(
-	include: string[],
-	exclude: string[],
-	remove: string[],
-) {
-	// 処理内容を記述
-	console.log(include + "\n" + exclude + "\n" + remove);
-}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,32 +1,12 @@
+import { get } from "node:http";
 import { importMCPSettings } from "../import-settings";
 import type { Config } from "../schemas";
+import { getPathFromClientName } from "../return-client-settings";
 
 export function listFunc(client?: string) {
-  let pathfromhomedir: string = ".mcp-manager.json";
-  switch (client) {
-    case "claude-code": {
-      pathfromhomedir = ".claude.json";
-      break;
-    }
-    case "gemini-cli": {
-      pathfromhomedir = ".gemini/settings.json";
-      break;
-    }
-    case "claude": {
-      pathfromhomedir =
-        "Library/Application Support/Claude/claude_desktop_config.json";
-      break;
-    }
-    case undefined:
-    case "": {
-      // デフォルトの.mcp-manager.jsonを使用
-      break;
-    }
-    default: {
-      throw new Error("無効なクライアント名です");
-    }
-  }
-  const obj: Config = importMCPSettings(pathfromhomedir);
+  const configPath = getPathFromClientName(client);
+
+  const obj: Config = importMCPSettings(configPath);
 
   const mcps = Object.keys(obj.mcpServers);
   Object.values(mcps).forEach((serverName) => {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,4 +1,3 @@
-import { get } from "node:http";
 import { importMCPSettings } from "../import-settings";
 import type { Config } from "../schemas";
 import { getPathFromClientName } from "../return-client-settings";

--- a/src/import-settings.ts
+++ b/src/import-settings.ts
@@ -1,13 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { ConfigSchema, type Config } from "./schemas";
 import { validateConfig } from "./validate";
 
-export function importMCPSettings(
-  pathfromhomedir: string = ".mcp-manager.json",
-) {
-  const filePath = join(homedir(), pathfromhomedir);
+export function importMCPSettings(filePath: string = ".mcp-manager.json") {
   if (!existsSync(filePath)) {
     throw new Error("ファイルが存在しません");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,12 @@ program
   .description("mcpサーバーをmcp-managerに登録します")
   .option("-e, --env [key=value...]", "環境変数を設定")
   .option("-f, --force", "強制上書き")
+  .option("--client [clientName]", "クライアント名")
   .argument("<name>", "MCPサーバー名")
   .argument("<command>", "実行コマンド")
   .argument("[args...]", "追加の引数")
   .action((name, command, args, options) => {
-    addFunc(name, command, args, options.force, options.env);
+    addFunc(name, command, args, options.client, options.force, options.env);
   });
 
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,28 @@
 import { program } from "commander";
 import { addFunc } from "./commands/add";
 import { listFunc } from "./commands/list";
-import { applyFunc } from "./commands/apply";
 
 program.version("0.0.1", "-v, --version");
 
 program
-	.command("list")
-	.description("mcp-managerに登録してある MCP サーバーを一覧表示します")
-	.option("-c, --client <clientName>", "クライアント名")
-	.action((options) => {
-		listFunc(options.client);
-	});
+  .command("list")
+  .description("mcp-managerに登録してある MCP サーバーを一覧表示します")
+  .option("-c, --client <clientName>", "クライアント名")
+  .action((options) => {
+    listFunc(options.client);
+  });
 
 program
-	.command("add")
-	.description("mcpサーバーをmcp-managerに登録します")
-	.option("-e, --env [key=value...]", "環境変数を設定")
-	.option("-c, --config <path>", "設定ファイルのパス")
-	.option("-f, --force", "強制上書き")
-	.argument("<name>", "MCPサーバー名")
-	.argument("<command>", "実行コマンド")
-	.argument("[args...]", "追加の引数")
-	.action((name, command, args, options) => {
-		addFunc(name, command, args, options.force, options.config, options.env);
-	});
-
-program
-	.command("apply")
-	.description("mcp-managerに登録してある MCP サーバーを一括適用します")
-	.option("-i, --include [includedServers...]", "適用するサーバー名")
-	.option("-e, --exclude [excludedServers...]", "除外するサーバー名")
-	.option("-r, --remove [removedServers...]", "削除するサーバー名")
-	.option("-c, --client [clients...]", "適用するエージェント名")
-	.action((options) => {
-		applyFunc(options.include, options.exclude, options.remove);
-	});
+  .command("add")
+  .description("mcpサーバーをmcp-managerに登録します")
+  .option("-e, --env [key=value...]", "環境変数を設定")
+  .option("-c, --config <path>", "設定ファイルのパス")
+  .option("-f, --force", "強制上書き")
+  .argument("<name>", "MCPサーバー名")
+  .argument("<command>", "実行コマンド")
+  .argument("[args...]", "追加の引数")
+  .action((name, command, args, options) => {
+    addFunc(name, command, args, options.force, options.config, options.env);
+  });
 
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,12 @@ program
   .command("add")
   .description("mcpサーバーをmcp-managerに登録します")
   .option("-e, --env [key=value...]", "環境変数を設定")
-  .option("-c, --config <path>", "設定ファイルのパス")
   .option("-f, --force", "強制上書き")
   .argument("<name>", "MCPサーバー名")
   .argument("<command>", "実行コマンド")
   .argument("[args...]", "追加の引数")
   .action((name, command, args, options) => {
-    addFunc(name, command, args, options.force, options.config, options.env);
+    addFunc(name, command, args, options.force, options.env);
   });
 
 program.parse();

--- a/src/return-client-settings.ts
+++ b/src/return-client-settings.ts
@@ -1,0 +1,27 @@
+export function getPathFromClientName(client: string = ""): string {
+  let pathfromhomedir: string = ".mcp-manager.json";
+  switch (client) {
+    case "claude-code": {
+      pathfromhomedir = ".claude.json";
+      break;
+    }
+    case "gemini-cli": {
+      pathfromhomedir = ".gemini/settings.json";
+      break;
+    }
+    case "claude": {
+      pathfromhomedir =
+        "Library/Application Support/Claude/claude_desktop_config.json";
+      break;
+    }
+    case undefined:
+    case "": {
+      // デフォルトの.mcp-manager.jsonを使用
+      break;
+    }
+    default: {
+      throw new Error("無効なクライアント名です");
+    }
+  }
+  return pathfromhomedir;
+}

--- a/src/return-client-settings.ts
+++ b/src/return-client-settings.ts
@@ -1,3 +1,6 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 export function getPathFromClientName(client: string = ""): string {
   let pathfromhomedir: string = ".mcp-manager.json";
   switch (client) {
@@ -23,5 +26,5 @@ export function getPathFromClientName(client: string = ""): string {
       throw new Error("無効なクライアント名です");
     }
   }
-  return pathfromhomedir;
+  return join(homedir(), pathfromhomedir);
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2,13 +2,13 @@ import { z } from "zod";
 
 // 1. スキーマを定義
 const MCPServerSchema = z.object({
-	command: z.string(),
-	args: z.array(z.string()),
-	env: z.record(z.string(), z.string()).optional(), // オプショナル
+  command: z.string(),
+  args: z.array(z.string()),
+  env: z.record(z.string(), z.string()).optional(), // オプショナル
 });
 
 export const ConfigSchema = z.object({
-	mcpServers: z.record(z.string(), MCPServerSchema), // キーは任意、値はMCPServerSchema
+  mcpServers: z.record(z.string(), MCPServerSchema), // キーは任意、値はMCPServerSchema
 });
 
 // スキーマから型を自動生成


### PR DESCRIPTION
## 概要
このPRでは、`apply`コマンドの削除と、コードの重複を削減するリファクタリングを実施しました。

## 主な変更内容

### 1. applyコマンドの削除
- `src/commands/apply.ts` を削除
- `src/index.ts` から apply コマンドの定義を削除
- 未実装のコマンドを整理

### 2. クライアント設定パス管理の改善
- 新規ファイル `src/return-client-settings.ts` を追加
- `getPathFromClientName()` 関数を導入し、クライアント名からパスを取得するロジックを一元化
- `list.ts` の重複したswitch文を削除

### 3. コードスタイルの統一
- タブインデントからスペースインデントに変更
- 全体的なコードフォーマットの統一

### 4. パラメータ構造の改善
- `add.ts` の `config` パラメータを `client` パラメータに変更
- `importMCPSettings()` 関数のパラメータを相対パスから絶対パスに変更
- パス結合ロジック(`join + homedir`)を `getPathFromClientName` に集約

## 変更統計
- 7ファイル変更
- 94行追加、106行削除（ネット12行削減）

## テスト計画
- [ ] `list` コマンドが正常に動作することを確認
- [ ] `add` コマンドが正常に動作することを確認
- [ ] 各クライアント（claude-code, gemini-cli, claude）で設定ファイルが正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)