### PR TITLE
refactor: client用語をappに統一

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,4 +1,4 @@
-import { getPathFromClientName } from "../return-client-settings";
+import { getPathFromAppName } from "../return-apps-settings";
 import { exportMCPSettings } from "../export-settings";
 import { importMCPSettings } from "../import-settings";
 import type { Config } from "../schemas";
@@ -7,12 +7,12 @@ export function addFunc(
   name: string,
   command: string,
   args: string[],
-  client?: string,
+  app?: string,
   force?: boolean,
   env?: string[],
 ) {
   console.log(
-    `name: ${name}\ncommand: ${command}\nargs: ${args}\nclient: ${client}\nforce: ${force}\nenv: ${env}`,
+    `name: ${name}\ncommand: ${command}\nargs: ${args}\napp: ${app}\nforce: ${force}\nenv: ${env}`,
   );
 
   let newEnv = {};
@@ -40,7 +40,7 @@ export function addFunc(
     );
   }
 
-  const filePath = getPathFromClientName(client);
+  const filePath = getPathFromAppName(app);
 
   const obj: Config = importMCPSettings(filePath);
   if (force || !(name in obj.mcpServers)) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,9 +1,9 @@
 import { importMCPSettings } from "../import-settings";
 import type { Config } from "../schemas";
-import { getPathFromClientName } from "../return-client-settings";
+import { getPathFromAppName } from "../return-apps-settings";
 
-export function listFunc(client?: string) {
-  const configPath = getPathFromClientName(client);
+export function listFunc(app?: string) {
+  const configPath = getPathFromAppName(app);
 
   const obj: Config = importMCPSettings(configPath);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ program.version("0.0.1", "-v, --version");
 program
   .command("list")
   .description("mcp-managerに登録してある MCP サーバーを一覧表示します")
-  .option("-c, --client <clientName>", "クライアント名")
+  .option("-a, --app <appName>", "アプリ名")
   .action((options) => {
-    listFunc(options.client);
+    listFunc(options.app);
   });
 
 program
@@ -17,12 +17,12 @@ program
   .description("mcpサーバーをmcp-managerに登録します")
   .option("-e, --env [key=value...]", "環境変数を設定")
   .option("-f, --force", "強制上書き")
-  .option("--client [clientName]", "クライアント名")
+  .option("--apps [appNames]", "アプリ名")
   .argument("<name>", "MCPサーバー名")
   .argument("<command>", "実行コマンド")
   .argument("[args...]", "追加の引数")
   .action((name, command, args, options) => {
-    addFunc(name, command, args, options.client, options.force, options.env);
+    addFunc(name, command, args, options.apps, options.force, options.env);
   });
 
 program.parse();

--- a/src/return-apps-settings.ts
+++ b/src/return-apps-settings.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const CLIENT_PATHS: Record<string, string> = {
+const APP_PATHS: Record<string, string> = {
   "claude-code": ".claude.json",
   "gemini-cli": ".gemini/settings.json",
   "claude-desktop":
@@ -10,12 +10,12 @@ const CLIENT_PATHS: Record<string, string> = {
 
 const DEFAULT_PATH = join(homedir(), ".mcp-manager.json");
 
-export function getPathFromClientName(client: string = ""): string {
-  if (!client) {
+export function getPathFromAppName(app: string = ""): string {
+  if (!app) {
     return DEFAULT_PATH;
   }
 
-  const path = CLIENT_PATHS[client];
+  const path = APP_PATHS[app];
 
   if (!path) {
     throw new Error("無効なクライアント名です");


### PR DESCRIPTION
## 概要
CLI全体で使用されている「client」という用語を「app」に統一するリファクタリングです。

## 変更内容
- `return-client-settings.ts` を `return-apps-settings.ts` にリネーム
- 関数名: `getPathFromClientName` → `getPathFromAppName`
- コマンドオプション:
  - `list`コマンド: `--client` → `--app`
  - `add`コマンド: `--client` → `--apps`
- すべての関連する変数名とパラメータ名を更新

## 理由
「app」はより一般的で分かりやすい用語であり、Claude Code、Cursor、Windsurf など様々なAIエージェントアプリケーションに対応するため、より適切な命名となります。

## テスト
- [ ] `bun src/index.ts list` コマンドの動作確認
- [ ] `bun src/index.ts add` コマンドの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)