### PR TITLE
feat: removeコマンドで複数のMCPサーバーを一度に削除可能に

### DIFF
--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -5,14 +5,16 @@ import {
 } from "../settings";
 import type { Config } from "../schemas";
 
-export function removeFunc(server: string, app: string) {
+export function removeFunc(servers: string[], app: string, force?: boolean) {
     const filePath = getPathFromAppName(app);
 
     const obj: Config = importMCPSettings(filePath);
-    if (server in obj.mcpServers) {
-        delete obj.mcpServers[server];
-    } else {
-        console.log(`Server ${server} not found`);
-    }
+    servers.forEach((server: string) => {
+        if (server in obj.mcpServers || force) {
+            delete obj.mcpServers[server];
+        } else {
+            console.log(`Server ${server} not found`);
+        }
+    })
     exportMCPSettings(obj, filePath);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,11 @@ program
 program
     .command("remove")
     .description("アプリから MCP サーバーを削除します")
-    .requiredOption("-s, --server <serverName>", "MCP サーバー名")
-    .option("-a, --apps [apps]", "アプリ名")
+    .requiredOption("-s, --servers [servers...]", "MCP サーバー名")
+    .option("-a, --app <app>", "アプリ名")
+    .option("-f --force", "強制上書き")
     .action((options) => {
-        removeFunc(options.server, options.apps);
+        removeFunc(options.servers, options.app, options.force);
     });
 
 program.parse();


### PR DESCRIPTION
## 概要
removeコマンドを拡張し、一度に複数のMCPサーバーを削除できるようにしました。

## 変更内容
- **複数サーバー削除対応**: `--servers` オプションで複数のサーバー名を配列として受け取れるように変更
- **強制削除オプション追加**: `--force` オプションを追加し、存在しないサーバーでもエラーにせず処理を続行
- **オプション名の整理**: `--app` を単数形に変更（一度に一つのアプリを対象）

## 変更されたファイル
- `src/commands/remove.ts`: removeFunc関数を配列処理に対応
- `src/index.ts`: コマンドオプション定義を更新

## 使用例
```bash
# 複数のサーバーを一度に削除
mcp-manager remove --servers server1 server2 server3 --app claude

# 存在しないサーバーでも処理を続行
mcp-manager remove --servers server1 server2 --app claude --force
```

## テスト計画
- [ ] 単一サーバーの削除が正常に動作することを確認
- [ ] 複数サーバーの削除が正常に動作することを確認
- [ ] 存在しないサーバーを削除しようとした場合のエラーメッセージを確認
- [ ] --forceオプションで存在しないサーバーも処理されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)