### PR TITLE
feat: removeコマンドで複数のMCPサーバーを一度に削除できるように拡張

### DIFF
--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -5,14 +5,16 @@ import {
 } from "../settings";
 import type { Config } from "../schemas";
 
-export function removeFunc(server: string, app: string) {
+export function removeFunc(servers: string[], app: string, force?: boolean) {
     const filePath = getPathFromAppName(app);
 
     const obj: Config = importMCPSettings(filePath);
-    if (server in obj.mcpServers) {
-        delete obj.mcpServers[server];
-    } else {
-        console.log(`Server ${server} not found`);
-    }
+    servers.forEach((server: string) => {
+        if (server in obj.mcpServers || force) {
+            delete obj.mcpServers[server];
+        } else {
+            console.log(`Server ${server} not found`);
+        }
+    })
     exportMCPSettings(obj, filePath);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,11 @@ program
 program
     .command("remove")
     .description("アプリから MCP サーバーを削除します")
-    .requiredOption("-s, --server <serverName>", "MCP サーバー名")
-    .option("-a, --apps [apps]", "アプリ名")
+    .requiredOption("-s, --servers [servers...]", "MCP サーバー名")
+    .option("-a, --app <app>", "アプリ名")
+    .option("-f --force", "強制上書き")
     .action((options) => {
-        removeFunc(options.server, options.apps);
+        removeFunc(options.servers, options.app, options.force);
     });
 
 program.parse();


### PR DESCRIPTION
## 概要
`remove`コマンドを拡張し、一度に複数のMCPサーバーを削除できるようにしました。また、`--force`オプションを追加して、存在しないサーバーも強制的に削除できるようにしました。

## 主な変更点

### 🔧 コマンドインターフェースの改善
- **以前**: 単一のサーバーのみ削除可能（`-s, --server <serverName>`）
- **現在**: 複数のサーバーを同時に削除可能（`-s, --servers [servers...]`）

### 🎯 実装の改善
1. **複数サーバー対応**
   - `removeFunc`関数のシグネチャを変更し、`servers: string[]`として配列を受け取るように
   - `forEach`でループ処理し、各サーバーを順次削除
   - 既存の削除ロジックは維持しつつ、バッチ処理に対応

2. **強制削除オプションの追加**
   - `--force`（`-f`）オプションを新規追加
   - 存在しないサーバー名でもエラーを出さずに処理を続行
   - 設定ファイルのクリーンアップ作業に便利

3. **オプション名の整理**
   - `--apps`を`--app`に変更し、単一アプリを明確に指定
   - より直感的なコマンドラインインターフェースに

## テスト方法
1. 複数サーバーの削除をテスト:
   ```bash
   mcp-manager remove -s server1 server2 server3 -a claude-code
   ```

2. 強制削除オプションのテスト:
   ```bash
   mcp-manager remove -s nonexistent-server -a claude-code --force
   ```

3. 以下を確認:
   - [ ] 複数のサーバーが正しく削除される
   - [ ] 存在しないサーバーに対して適切なメッセージが表示される
   - [ ] `--force`オプションでエラーなく処理が完了する
   - [ ] 設定ファイルが正しく更新される

## 技術的な改善点
- **保守性**: 単一責任の原則を維持しつつ、バッチ処理に対応
- **可読性**: `forEach`を使用した明確なループ処理
- **拡張性**: 将来的な機能追加（例: ドライランモード）に対応しやすい構造

🤖 Generated with [Claude Code](https://claude.com/claude-code)